### PR TITLE
Adjusted rust config so libstdc++6 gets linked statically

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,0 +1,13 @@
+[target.x86_64-pc-windows-gnu]
+rustflags = [
+    "-C", "target-feature=+crt-static",
+    "-C", "link-args=-static-libgcc -static-libstdc++"
+]
+
+[build.aarch64-pc-windows-gnullvm]
+linker = "aarch64-w64-mingw32-clang++"
+ar = "aarch64-w64-mingw32-llvm-ar"
+
+[build.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+ar = "aarch64-linux-gnu-ar"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,20 +12,9 @@ crate-type = ["cdylib"]
 csbindgen = "1.9.3"
 
 [dependencies]
-tokenizers = "0.21.1"
+tokenizers = { version = "0.21.1", default-features = false, features = ["onig", "progressbar"] }
 once_cell = "1.19.0"
 uuid = { version = "1.8.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
 
 [build]
 target = "x86_64-pc-windows-gnullvm"
-
-[build.aarch64-pc-windows-gnullvm]
-linker = "aarch64-w64-mingw32-clang++"
-ar = "aarch64-w64-mingw32-llvm-ar"
-
-[build.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"
-ar = "aarch64-linux-gnu-ar"
-
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"


### PR DESCRIPTION
Hey @sappho192 👋

this PR fixes #24. It compiles now without the linking to `libstdc++` but it still needs some more testing to see if everything still works 🙂