### PR TITLE
fix: Fixed win arm64 dependency on libunwind.dll

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -5,7 +5,10 @@ rustflags = [
 ]
 
 [target.aarch64-pc-windows-gnullvm]
-rustflags = ["-C", "target-feature=+crt-static"]
+rustflags = [
+    "-C", "target-feature=+crt-static",
+    "-C", "link-args=-static-libgcc -static-libstdc++"
+]
 
 [build.aarch64-pc-windows-gnullvm]
 linker = "aarch64-w64-mingw32-clang++"

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -4,6 +4,9 @@ rustflags = [
     "-C", "link-args=-static-libgcc -static-libstdc++"
 ]
 
+[target.aarch64-pc-windows-gnullvm]
+rustflags = ["-C", "target-feature=+crt-static"]
+
 [build.aarch64-pc-windows-gnullvm]
 linker = "aarch64-w64-mingw32-clang++"
 ar = "aarch64-w64-mingw32-llvm-ar"


### PR DESCRIPTION
This fixes #34. Rust somehow created a dependency on libunwind.dll which is not satisfied in standard windows environments. Not it gets statically linked.

Reference: https://users.rust-lang.org/t/is-there-a-way-to-statically-link-libunwind-on-x86-64-pc-windows-gnullvm/130542