### PR TITLE
Tune build profile to improve performance

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,5 +16,10 @@ tokenizers = { version = "0.21.1", default-features = false, features = ["onig",
 once_cell = "1.19.0"
 uuid = { version = "1.8.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
 
+[profile.release]
+lto = true
+codegen-units = 1
+panic = "abort"
+
 [build]
 target = "x86_64-pc-windows-gnullvm"


### PR DESCRIPTION
This is essentially a "free performance boost" that enables full link-time optimization within a single codegen unit for the release build. This allows cross-module (cross-crate) code inlining, and removes unnecessary frame pointer management leading to significant performance gains (~6.38M ops/sec vs ~6.18M ops/sec on my machine) at the expense of increased compilation time, which is going to take tens of seconds, which is, as far as I believe, acceptable for release builds.