### PR TITLE
Bump dependency versions

### DIFF
--- a/dotnet/Tokenizers.DotNet/Tokenizers.DotNet.csproj
+++ b/dotnet/Tokenizers.DotNet/Tokenizers.DotNet.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="csbindgen" Version="1.9.4">
+    <PackageReference Include="csbindgen" Version="1.9.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,12 +9,11 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-csbindgen = "1.9.3"
+csbindgen = "1.9.5"
 
 [dependencies]
-tokenizers = { version = "0.21.1", default-features = false, features = ["onig", "progressbar"] }
-once_cell = "1.19.0"
-uuid = { version = "1.8.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
+tokenizers = { version = "0.21.4", default-features = false, features = ["onig"] }
+uuid = { version = "1.8.0", features = ["v4", "fast-rng"] }
 mimalloc = "0.1.47"
 
 [profile.release]


### PR DESCRIPTION
This just bumps the dependencies and removes some features from the dependencies that are not required for the current implementation, it speeds the build a bit.