### PR TITLE
Prevent memory leaks and improve the blitting layer

### DIFF
--- a/dotnet/Tokenizers.DotNet.Test/FFITest.cs
+++ b/dotnet/Tokenizers.DotNet.Test/FFITest.cs
@@ -24,9 +24,16 @@ namespace Tokenizers.DotNet.Test
             fixed (char* p = path)
             {
                 var tokenizerResult = NativeMethods.tokenizer_initialize((ushort*)p, path.Length);
-                Assert.Equal(TokenizerErrorCode.Success, tokenizerResult.error_code);
-                var str = Encoding.UTF8.GetString(tokenizerResult.data->AsSpan());
-                sessionId = new string(str);
+                try
+                {
+                    Assert.Equal(TokenizerErrorCode.Success, tokenizerResult.error_code);
+                    sessionId = Encoding.UTF8.GetString(tokenizerResult.data->ptr, tokenizerResult.data->length);
+                }
+                finally
+                {
+                    NativeMethods.free_u8_string(tokenizerResult.data);
+                }
+
                 Assert.True(sessionId.Length > 0);
             }
         }

--- a/dotnet/Tokenizers.DotNet/ByteBuffer.cs
+++ b/dotnet/Tokenizers.DotNet/ByteBuffer.cs
@@ -1,20 +1,19 @@
 ﻿using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace CsBindgen
 {
-    // C# side span utility 
-    // From https://github.com/Cysharp/csbindgen/blob/main/README.md
     partial struct ByteBuffer
     {
-        public unsafe Span<byte> AsSpan()
+        public unsafe T[] ToArray<T>()
+            where T : unmanaged
         {
-            return new Span<byte>(ptr, length);
-        }
+            var array = new T[length / Unsafe.SizeOf<T>()];
+            fixed (void* arrayPtr = array)
+            {
+                Unsafe.CopyBlock(arrayPtr, ptr, unchecked((uint)length));
+            }
 
-        public unsafe Span<T> AsSpan<T>()
-        {
-            return MemoryMarshal.CreateSpan(ref Unsafe.AsRef<T>(ptr), length / Unsafe.SizeOf<T>());
+            return array;
         }
     }
 }


### PR DESCRIPTION
In some parts of the current implementation, the deallocation of memory, allocated by the Rust FFI was overlooked in a couple of methods. Also, the `Span` APIs were used where simpler pointer-based versions exist and some string duplication was done.

These issues were improved upon, without any functionality changes.