### PR TITLE
Use mimalloc allocator to improve performance

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,6 +15,7 @@ csbindgen = "1.9.3"
 tokenizers = { version = "0.21.1", default-features = false, features = ["onig", "progressbar"] }
 once_cell = "1.19.0"
 uuid = { version = "1.8.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
+mimalloc = "0.1.47"
 
 [profile.release]
 lto = true

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -107,6 +107,9 @@ pub unsafe extern "C" fn csharp_to_rust_u32_array(buffer: *const u32, len: i32) 
     println!("{:?}", vec);
 }
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 // Tokenizer stuff starts here
 use std::collections::HashMap;
 use std::fmt;


### PR DESCRIPTION
Since the `tokenizers` library unigram trie implementation allocates a lot and system allocator (at least on Windows) doesn't cope well with this kind of load, using an alternate allocator that works well for rapid allocation/deallocation of chunks of memory bumps the performance from ~6.2M ops/sec to ~8.5M ops/sec.