### PR TITLE
Add lifetime management

### DIFF
--- a/dotnet/Tokenizers.DotNet.Test/LifetimeTests.cs
+++ b/dotnet/Tokenizers.DotNet.Test/LifetimeTests.cs
@@ -1,0 +1,24 @@
+namespace Tokenizers.DotNet.Test;
+
+public class LifetimeTests
+{
+    [Fact]
+    public void DisposeWorks()
+    {
+        var tokenizer = new Tokenizer(Models.GetFilePath(ModelId.KoGpt2));
+        tokenizer.Dispose();
+        Assert.Throws<ObjectDisposedException>(() => tokenizer.Encode("abc"));
+    }
+
+    [Fact]
+    public void MultiDisposeWorks()
+    {
+        var tokenizer = new Tokenizer(Models.GetFilePath(ModelId.KoGpt2));
+        for (var i = 0; i < 7; i++)
+        {
+            tokenizer.Dispose();
+        }
+
+        Assert.Throws<ObjectDisposedException>(() => tokenizer.Encode("abc"));
+    }
+}

--- a/dotnet/Tokenizers.DotNet/Tokenizer.cs
+++ b/dotnet/Tokenizers.DotNet/Tokenizer.cs
@@ -30,6 +30,11 @@ namespace Tokenizers.DotNet
 
         ~Tokenizer()
         {
+            if (sessionId is null)
+            {
+                return;
+            }
+
             fixed (char* cp = sessionId)
             {
                 NativeMethods.tokenizer_cleanup((ushort*)cp, sessionId.Length);

--- a/dotnet/Tokenizers.DotNet/Tokenizer.cs
+++ b/dotnet/Tokenizers.DotNet/Tokenizer.cs
@@ -3,9 +3,8 @@ using System.Text;
 
 namespace Tokenizers.DotNet
 {
-    public class Tokenizer
+    public sealed class Tokenizer
     {
-        private Tokenizer() { }
         private readonly string sessionId;
 
         /// <summary>

--- a/dotnet/Tokenizers.DotNet/Tokenizer.cs
+++ b/dotnet/Tokenizers.DotNet/Tokenizer.cs
@@ -28,6 +28,14 @@ namespace Tokenizers.DotNet
             }
         }
 
+        ~Tokenizer()
+        {
+            fixed (char* cp = sessionId)
+            {
+                NativeMethods.tokenizer_cleanup((ushort*)cp, sessionId.Length);
+            }
+        }
+
         /// <summary>
         /// Throws exception if error occured from native library.
         /// </summary>
@@ -114,6 +122,8 @@ namespace Tokenizers.DotNet
 
                 ValidateErrorCode(errorCode);
             }
+
+            GC.SuppressFinalize(this);
         }
 
         private string GetLastError()

--- a/dotnet/Tokenizers.DotNet/Tokenizer.cs
+++ b/dotnet/Tokenizers.DotNet/Tokenizer.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace Tokenizers.DotNet
 {
-    public sealed class Tokenizer
+    public unsafe sealed class Tokenizer : IDisposable
     {
         private readonly string sessionId;
 
@@ -13,26 +13,17 @@ namespace Tokenizers.DotNet
         /// <param name="vocabPath"></param>
         public Tokenizer(string vocabPath)
         {
-            unsafe
+            fixed (char* p = vocabPath)
             {
-                fixed (char* p = vocabPath)
+                var tokenizerResult = NativeMethods.tokenizer_initialize((ushort*)p, vocabPath.Length);
+                ValidateErrorCode(tokenizerResult.error_code);
+                try
                 {
-                    var tokenizerResult = NativeMethods.tokenizer_initialize((ushort*)p, vocabPath.Length);
-                    if (tokenizerResult.error_code == 0)
-                    {
-                        try
-                        {
-                            sessionId = Encoding.UTF8.GetString(tokenizerResult.data->ptr, tokenizerResult.data->length);
-                        }
-                        finally
-                        {
-                            NativeMethods.free_u8_string(tokenizerResult.data);
-                        }
-                    }
-                    else
-                    {
-                        throw new TokenizerException(GetLastError(), (int)tokenizerResult.error_code);
-                    }
+                    sessionId = Encoding.UTF8.GetString(tokenizerResult.data->ptr, tokenizerResult.data->length);
+                }
+                finally
+                {
+                    NativeMethods.free_u8_string(tokenizerResult.data);
                 }
             }
         }
@@ -45,34 +36,22 @@ namespace Tokenizers.DotNet
         /// <exception cref="TokenizerException"></exception>
         public uint[] Encode(string text)
         {
-            uint[] result;
-            unsafe
+            fixed (char* p = sessionId)
             {
-                fixed (char* p = sessionId)
+                fixed (char* pt = text)
                 {
-                    fixed (char* pt = text)
+                    var tokenizerResult = NativeMethods.tokenizer_encode((ushort*)p, sessionId.Length, (ushort*)pt, text.Length);
+                    ValidateErrorCode(tokenizerResult.error_code);
+                    try
                     {
-                        var tokenizerResult = NativeMethods.tokenizer_encode((ushort*)p, sessionId.Length, (ushort*)pt, text.Length);
-                        if (tokenizerResult.error_code == 0)
-                        {
-                            try
-                            {
-                                result = tokenizerResult.data->ToArray<uint>();
-                            }
-                            finally
-                            {
-                                NativeMethods.free_u8_string(tokenizerResult.data);
-                            }
-                        }
-                        else
-                        {
-                            throw new TokenizerException(GetLastError(), (int)tokenizerResult.error_code);
-                        }
+                        return tokenizerResult.data->ToArray<uint>();
+                    }
+                    finally
+                    {
+                        NativeMethods.free_u8_string(tokenizerResult.data);
                     }
                 }
             }
-
-            return result;
         }
 
         /// <summary>
@@ -82,37 +61,24 @@ namespace Tokenizers.DotNet
         /// <returns></returns>
         public string Decode(uint[] tokens)
         {
-            string result = string.Empty;
-            unsafe
+            fixed (uint* p = tokens)
             {
-                // Console.WriteLine($"Input tokens: {string.Join(", ", tokens)}");
-                fixed (uint* p = tokens)
+                fixed (char* cp = sessionId)
                 {
-                    fixed (char* cp = sessionId)
+                    var tokenizerResult = NativeMethods.tokenizer_decode(
+                        (ushort*)cp, sessionId.Length,
+                        p, tokens.Length);
+                    ValidateErrorCode(tokenizerResult.error_code);
+                    try
                     {
-                        var tokenizerResult = NativeMethods.tokenizer_decode(
-                            (ushort*)cp, sessionId.Length,
-                            p, tokens.Length);
-                        if (tokenizerResult.error_code == 0)
-                        {
-                            try
-                            {
-                                result = Encoding.UTF8.GetString(tokenizerResult.data->ptr, tokenizerResult.data->length);
-                            }
-                            finally
-                            {
-                                NativeMethods.free_u8_string(tokenizerResult.data);
-                            }
-                        }
-                        else
-                        {
-                            throw new TokenizerException(GetLastError(), (int)tokenizerResult.error_code);
-                        }
+                        return Encoding.UTF8.GetString(tokenizerResult.data->ptr, tokenizerResult.data->length);
+                    }
+                    finally
+                    {
+                        NativeMethods.free_u8_string(tokenizerResult.data);
                     }
                 }
             }
-
-            return result;
         }
 
         /// <summary>
@@ -121,49 +87,61 @@ namespace Tokenizers.DotNet
         /// <returns></returns>
         public string GetVersion()
         {
-            string result = string.Empty;
-            unsafe
+            fixed (char* cp = sessionId)
             {
-                fixed (char* cp = sessionId)
+                var tokenizerResult = NativeMethods.get_version((ushort*)cp, sessionId.Length);
+                ValidateErrorCode(tokenizerResult.error_code);
+                try
                 {
-                    var tokenizerResult = NativeMethods.get_version((ushort*)cp, sessionId.Length);
-                    if (tokenizerResult.error_code == 0)
-                    {
-                        try
-                        {
-                            result = Encoding.UTF8.GetString(tokenizerResult.data->ptr, tokenizerResult.data->length);
-                        }
-                        finally
-                        {
-                            NativeMethods.free_u8_string(tokenizerResult.data);
-                        }
-                    }
-                    else
-                    {
-                        throw new TokenizerException(GetLastError(), (int)tokenizerResult.error_code);
-                    }
+                    return Encoding.UTF8.GetString(tokenizerResult.data->ptr, tokenizerResult.data->length);
+                }
+                finally
+                {
+                    NativeMethods.free_u8_string(tokenizerResult.data);
                 }
             }
+        }
 
-            return result;
+        public void Dispose()
+        {
+            fixed (char* cp = sessionId)
+            {
+                var errorCode = NativeMethods.tokenizer_cleanup((ushort*)cp, sessionId.Length);
+                if (errorCode == TokenizerErrorCode.InvalidSessionId)
+                {
+                    return;
+                }
+
+                ValidateErrorCode(errorCode);
+            }
         }
 
         private string GetLastError()
         {
-            var result = string.Empty;
-            unsafe
+            var errorBytes = NativeMethods.get_last_error_message();
+            try
             {
-                var errorBytes = NativeMethods.get_last_error_message();
-                try
-                {
-                    result = Encoding.UTF8.GetString(errorBytes->ptr, errorBytes->length);
-                }
-                finally
-                {
-                    NativeMethods.free_u8_string(errorBytes);
-                }
+                return Encoding.UTF8.GetString(errorBytes->ptr, errorBytes->length);
             }
-            return result;
+            finally
+            {
+                NativeMethods.free_u8_string(errorBytes);
+            }
+        }
+
+        private void ValidateErrorCode(TokenizerErrorCode errorCode)
+        { 
+            switch (errorCode)
+            {
+                case TokenizerErrorCode.Success:
+                    return;
+
+                case TokenizerErrorCode.InvalidSessionId:
+                    throw new ObjectDisposedException(nameof(Tokenizer));
+
+                default:
+                    throw new TokenizerException(GetLastError(), (int)errorCode);
+            }
         }
     }
 }


### PR DESCRIPTION
Currently, the FFI has the `tokenizer_cleanup` method, which is unused. I believe that `Tokenizer` should implement `IDisposable` and use it, and this PR does exactly that. Also it adds a couple of `IDisposable` tests.

The `Dispose` implementation is simple, but contrary to most frequent solution does not involve adding an `_disposed` field relying on the FFI returning the `InvalidSessionId` error code. Given how `Tokenizer` is built, the only real reason for this error to occur is for `Dispose` to be called previously.
Also this PR:
- removes some repetitive code for error/status handling, replacing it with a `ValidateErrorCode` method
- marks `Tokenizer` as `sealed` (to prevent incorrect `Dispose` overrides)
- marks `Tokenizer` as `unsafe` since almost all of its methods are unsafe, given it's mostly an FFI wrapper, so there is less code text in the implementation
- removes the private `Tokenizer` default constructor that probably was a leftover from a test implementation

If reviewing by hand, I recommend checking the resulting files instead of diffs, because of a lot of changes due to indentation/formatting.