### PR TITLE
Add macOS (osx-x64, osx-arm64) support

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -36,4 +36,6 @@ jobs:
           nuget/win-arm64/Tokenizers.DotNet.runtime.win-arm64.*.nupkg
           nuget/linux-x64/Tokenizers.DotNet.runtime.linux-x64.*.nupkg
           nuget/linux-arm64/Tokenizers.DotNet.runtime.linux-arm64.*.nupkg
+          nuget/osx-x64/Tokenizers.DotNet.runtime.osx-x64.*.nupkg
+          nuget/osx-arm64/Tokenizers.DotNet.runtime.osx-arm64.*.nupkg
           nuget/Tokenizers.DotNet.*.nupkg

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,14 @@ nuget/win-x64/*
 nuget/win-arm64/*
 nuget/linux-x64/*
 nuget/linux-arm64/*
+nuget/osx-x64/*
+nuget/osx-arm64/*
 !Tokenizers.DotNet.runtime.win-x64.nuspec
 !Tokenizers.DotNet.runtime.win-arm64.nuspec
 !Tokenizers.DotNet.runtime.linux-x64.nuspec
 !Tokenizers.DotNet.runtime.linux-arm64.nuspec
+!Tokenizers.DotNet.runtime.osx-x64.nuspec
+!Tokenizers.DotNet.runtime.osx-arm64.nuspec
 nuget/Tokenizers.DotNet.*.nupkg
 out/
 

--- a/nuget/osx-arm64/Tokenizers.DotNet.runtime.osx-arm64.nuspec
+++ b/nuget/osx-arm64/Tokenizers.DotNet.runtime.osx-arm64.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package >
+  <metadata>
+    <id>Tokenizers.DotNet.runtime.osx-arm64</id>
+    <version>1.3.0</version>
+    <title>Tokenizers.DotNet.runtime.osx-arm64</title>
+    <authors>sappho192</authors>
+    <owners>sappho192</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <!-- <icon>icon.png</icon> -->
+    <projectUrl>https://github.com/sappho192/Tokenizers.DotNet</projectUrl>
+    <repository type="git" url="https://github.com/sappho192/Tokenizers.DotNet.git" branch="$RepositoryBranch$" commit="$RepositoryCommit$" />
+    <description>Native(Rust) wrapper of HuggingFace Tokenizers library.</description>
+    <copyright>Copyright (c) Taein Kim(sappho192)</copyright>
+    <tags>tokenizers;rust;huggingface;tokenizer;gpt</tags>
+  </metadata>
+  <files>
+    <file src="libhf_tokenizers.dylib" target="runtimes\osx-arm64\native" />
+  </files>
+</package>

--- a/nuget/osx-x64/Tokenizers.DotNet.runtime.osx-x64.nuspec
+++ b/nuget/osx-x64/Tokenizers.DotNet.runtime.osx-x64.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package >
+  <metadata>
+    <id>Tokenizers.DotNet.runtime.osx-x64</id>
+    <version>1.3.0</version>
+    <title>Tokenizers.DotNet.runtime.osx-x64</title>
+    <authors>sappho192</authors>
+    <owners>sappho192</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <!-- <icon>icon.png</icon> -->
+    <projectUrl>https://github.com/sappho192/Tokenizers.DotNet</projectUrl>
+    <repository type="git" url="https://github.com/sappho192/Tokenizers.DotNet.git" branch="$RepositoryBranch$" commit="$RepositoryCommit$" />
+    <description>Native(Rust) wrapper of HuggingFace Tokenizers library.</description>
+    <copyright>Copyright (c) Taein Kim(sappho192)</copyright>
+    <tags>tokenizers;rust;huggingface;tokenizer;gpt</tags>
+  </metadata>
+  <files>
+    <file src="libhf_tokenizers.dylib" target="runtimes\osx-x64\native" />
+  </files>
+</package>


### PR DESCRIPTION
## Summary

- Add macOS cross-compilation stages to the Dockerfile using `cargo-zigbuild` for both `x86_64-apple-darwin` and `aarch64-apple-darwin` targets
- Add `Tokenizers.DotNet.runtime.osx-arm64` and `Tokenizers.DotNet.runtime.osx-x64` NuGet runtime package nuspecs
- Update `.gitignore` for the new `nuget/osx-*` directories
- Update CI workflow to include macOS packages in build artifacts

## Motivation

There are currently no macOS runtime packages for Tokenizers.DotNet, which means any .NET project consuming the library on macOS fails with:

```
DllNotFoundException: Unable to load shared library 'hf_tokenizers'
```

This is a blocker for local development and testing on Apple Silicon Macs.

## Approach

Uses [`cargo-zigbuild`](https://github.com/rust-cross/cargo-zigbuild) to cross-compile from Linux to macOS inside Docker, avoiding the need for a macOS runner or the `osxcross` toolchain. Since the `tokenizers` crate is pure Rust with no external C dependencies, `cargo-zigbuild` works cleanly.

The existing `build_dotnet.ps1` already auto-discovers `.nuspec` files and checks for `.dylib` extensions, so no script changes were needed.

## Verification

- Built `libhf_tokenizers.dylib` natively on Apple Silicon (aarch64-apple-darwin)
- Packed `Tokenizers.DotNet.runtime.osx-arm64.1.3.0.nupkg` locally
- Verified the tokenizer loads successfully in a .NET 10 integration test on macOS